### PR TITLE
Add locks to reports fetching (merge 2nd)

### DIFF
--- a/server/go.sum
+++ b/server/go.sum
@@ -1,7 +1,13 @@
+git.sr.ht/~sbinet/gg v0.3.1 h1:LNhjNn8DerC8f9DHLz6lS0YYul/b602DUxDgGkd/Aik=
+github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b h1:slYM766cy2nI3BwyRiyQj/Ud48djTMtMebDqepE95rw=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/go-fonts/liberation v0.2.0 h1:jAkAWJP4S+OsrPLZM4/eC9iW7CtHy+HBXrEwZXWo5VM=
+github.com/go-latex/latex v0.0.0-20210823091927-c0d11ff05a81 h1:6zl3BbBhdnMkpSj2YY30qV3gDcVBGtFgVsV3+/i+mKQ=
+github.com/go-pdf/fpdf v0.6.0 h1:MlgtGIfsdMEEQJr2le6b/HNr1ZlQwxyWr77r2aj2U/8=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
@@ -15,6 +21,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e h1:1SzTfNOXwIS2oWiMF+6qu0OUDKb0dauo6MoDUQyu+yU=
 golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
+golang.org/x/image v0.0.0-20220302094943-723b81ca9867 h1:TcHcE0vrmgzNH1v3ppjcMGbhG5+9fMuvOmUYwNEF4q4=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -31,6 +38,7 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
@@ -39,3 +47,4 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/plot v0.11.0 h1:z2ZkgNqW34d0oYUzd80RRlc0L9kWtenqK4kflZG1lGc=
 gonum.org/v1/plot v0.11.0/go.mod h1:fH9YnKnDKax0u5EzHVXvhN5HJwtMFWIOLNuhgUahbCQ=
+rsc.io/pdf v0.1.1 h1:k1MczvYDUvJBe93bYd7wrZLLUEcLZAuF824/I4e5Xr4=

--- a/server/stycoon/reports.go
+++ b/server/stycoon/reports.go
@@ -38,8 +38,8 @@ func (game *Game) fillCombats(tick *int64) error {
 		newReports = append(newReports, combat)
 	}
 	game.Ready.Lock()
-	defer game.Ready.Unlock()
 	game.Reports.Combat = append(game.Reports.Combat, newReports...)
+	game.Ready.Unlock()
 	return nil
 }
 
@@ -67,8 +67,8 @@ func (game *Game) fillProfiling(tick *int64) error {
 		newReports = append(newReports, profiling)
 	}
 	game.Ready.Lock()
-	defer game.Ready.Unlock()
 	game.Reports.Profiling = append(game.Reports.Profiling, newReports...)
+	game.Ready.Unlock()
 	return nil
 }
 
@@ -88,7 +88,6 @@ func (game *Game) fillPricesAndAmounts(tick *int64) error {
 	// TODO: Rewrite this to batch write new reports like we do for Combat and Profiling
 	//	 if this lock takes too long and slows down the game.
 	game.Ready.Lock()
-	defer game.Ready.Unlock()
 	if game.Reports.Prices == nil {
 		game.Reports.Prices = make(map[string]map[string]int64)
 	}
@@ -123,6 +122,7 @@ func (game *Game) fillPricesAndAmounts(tick *int64) error {
 		amountValue[strTick] = amount
 		game.Reports.ResourceAmounts[strResource] = amountValue
 	}
+	game.Ready.Unlock()
 	return nil
 }
 
@@ -142,7 +142,6 @@ func (game *Game) fillScores(tick *int64) error {
 	// TODO: Rewrite this to batch write new reports like we do for Combat and Profiling
 	//	 if this lock takes too long and slows down the game.
 	game.Ready.Lock()
-	defer game.Ready.Unlock()
 	if game.Reports.Scores == nil {
 		game.Reports.Scores = make(map[string]ScoreValue)
 	}
@@ -175,6 +174,7 @@ func (game *Game) fillScores(tick *int64) error {
 
 		game.Reports.Scores[strconv.Itoa(int(player))] = scoreValue
 	}
+	game.Ready.Unlock()
 	return nil
 }
 
@@ -203,16 +203,16 @@ func (game *Game) fillTrades(tick *int64) error {
 		newReports = append(newReports, trade)
 	}
 	game.Ready.Lock()
-	defer game.Ready.Unlock()
 	game.Reports.Trade = append(game.Reports.Trade, newReports...)
+	game.Ready.Unlock()
 	return nil
 }
 
 func (game *Game) fillSeasonAndTick() {
 	game.Ready.Lock()
-	defer game.Ready.Unlock()
 	game.Reports.Tick = game.Tick.Tick
 	game.Reports.Season = game.Tick.Season
+	game.Ready.Unlock()
 }
 
 // nil tick means fetching all previous ticks
@@ -260,8 +260,6 @@ func (game *Game) fillAllReportsSinceSeasonStart() {
 
 func (game *Game) getDataReports() DataReports {
 	var tickReports DataReports
-	game.Ready.Lock()
-	defer game.Ready.Unlock()
 	tick := game.Tick.Tick - 1
 	if tick < 0 {
 		return tickReports

--- a/server/stycoon/reports.go
+++ b/server/stycoon/reports.go
@@ -254,7 +254,9 @@ func (game *Game) fillAllReportsForPreviousTick() {
 }
 
 func (game *Game) fillAllReportsSinceSeasonStart() {
+	game.Ready.Lock()
 	game.Reports = Reports{}
+	game.Ready.Unlock()
 	game.getReports(nil)
 }
 


### PR DESCRIPTION
- For simple reports updates I batch the data and append it at once. I only lock the game for the batched update.
- For more complex updates I have just locked the game for the entire time of the reports update. I could batch the changes but it would be painful and error-prone. We should do it if we notice slowdowns because of the locks.

NOTE: I have also ran `docker-compose up server-tidy`. I can remove it from the PR if you want.